### PR TITLE
Added orange color on marked roles

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -137,6 +137,7 @@ function strikeThrough(target){
         text1 = $(this).text();
         if(text1 == target && $(this).css('textDecoration') != 'line-through'){
            $(this).css('textDecoration', 'line-through');
+           $(this).css('color', '#df691a');
            return false;
         }
     });
@@ -149,7 +150,7 @@ function updateFilteredList(matches) //makes change to list of roles to click on
     {
         $("#rolelist").append("<span class = 'filteredrole'>" + role + "</span><br>");
     });
-    
+
     $(".filteredrole").click(function(){
         var text = $(this).text();
         var text1, target;
@@ -395,20 +396,21 @@ function updateFilteredList(matches) //makes change to list of roles to click on
         $("#filter").val("");
         updateFilteredList(roles);
     });
-    
+
 }
 
-$(document).ready(function() 
+$(document).ready(function()
 {
     updateFilteredList(roles);
-    $(".role").mousedown(function(event) 
+    $(".role").mousedown(function(event)
     {
         if(event.which == 1)
         {
             if($(this).css('textDecoration') == 'line-through')
             {
                 $(this).css('textDecoration', 'none');
-                
+                $(this).css('color', '#ebebeb');
+
                 switch($(this).text()){
                     case "Jailor":
                         jailor = false;
@@ -525,6 +527,7 @@ $(document).ready(function()
                 }
             } else {
                 $(this).css('textDecoration', 'line-through');
+                $(this).css('color', '#df691a');
                 switch($(this).text()){
                     case "Jailor":
                         jailor = true;
@@ -585,9 +588,9 @@ $(document).ready(function()
                    .attr('data-original-title', window.prompt("Create Note", origTooltip))
                    .tooltip('fixTitle')
                    .tooltip('show');
-            
+
         }
-        
+
     });
 
     $("#filter").on('input', function() //check for changes in filter
@@ -610,5 +613,5 @@ $(document).ready(function()
 
 
 
-    
+
 });


### PR DESCRIPTION
Hey, I've been enjoying your site lately, but I've noticed that elements with lines through them are really hard to notice at a glance. So, I added an orange color (matching the navbar) to them in the same style you applied line-through.

When a role is marked, the color `#df691a` is applied. When the same role is unmarked, the color `ebebeb` is reapplied.

# Demo

| Original uncolored marks: | Colored marks: |
|:-:|:-:|
| ![image](https://cloud.githubusercontent.com/assets/9123458/17081107/851c24dc-5110-11e6-81ae-69a4503872c3.png) | ![image](https://cloud.githubusercontent.com/assets/9123458/17081101/4e481eac-5110-11e6-8ec5-147a8e70129f.png) |

As you can see, it's a small change, but I really think your other users would benefit from it, too.


